### PR TITLE
Prevent NullPointerException in SonarClient.java

### DIFF
--- a/src/main/java/com/komodin/sonar/slacknotifier/sonarclient/SonarClient.java
+++ b/src/main/java/com/komodin/sonar/slacknotifier/sonarclient/SonarClient.java
@@ -60,6 +60,9 @@ public class SonarClient {
         MeasureHistory response = gson.fromJson(getResponse.body(), MeasureHistory.class);
         List<ProjectMeasure> result = new ArrayList<>();
 
+        if (response == null)
+            return result;
+
         for (MeasureHistoryDetails m : response.getMeasures()){
             ProjectMeasure pm = new ProjectMeasure();
             pm.setMetric(m.getMetric());


### PR DESCRIPTION
```
2025.06.07 11:22:33 ERROR ce[...][o.s.c.t.p.a.p.PostProjectAnalysisTasksExecutor] Execution of task class com.komodin.sonar.slacknotifier.extension.task.SlackPostProjectAnalysisTask failed
java.lang.NullPointerException: Cannot invoke "com.komodin.sonar.slacknotifier.sonarclient.MeasureHistory.getMeasures()" because "response" is null
	at com.komodin.sonar.slacknotifier.sonarclient.SonarClient.getMeasures(SonarClient.java:63)
	at com.komodin.sonar.slacknotifier.extension.task.SlackPostProjectAnalysisTask.finished(SlackPostProjectAnalysisTask.java:97)
	at org.sonar.ce.task.projectanalysis.api.posttask.PostProjectAnalysisTasksExecutor.executeTask(PostProjectAnalysisTasksExecutor.java:101)
```